### PR TITLE
Backdates Version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "6.5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/output.tf
+++ b/output.tf
@@ -1,7 +1,7 @@
 output "subscription_id" {
-  value = google_pubsub_subscription.subscription.id  
+  value = google_pubsub_subscription.subscription.id
 }
 
 output "subscription_name" {
-  value = google_pubsub_subscription.subscription.name  
+  value = google_pubsub_subscription.subscription.name
 }


### PR DESCRIPTION
Backdates the version from `6.5` to `~> 6.0` to try and trouble shoot an issue when adding it to an existing terraform state. 
