### PR TITLE
Update Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
-# terraform-google-ddm-pubsub-subscription
-Creates a Pub/Sub subscription.
+# Google PubSub Subscription
+
+This module create a Google PubSub Subscription as as well as a Topic/Subscription for Dead Letters. 
+
+We found that in order to follow the documentation for the provider, we were constantly having to create a ton of resources which increased the potential for mistakes. This module helps make sure it's more streamlined in our environment. 
+
+# Terraform-Docs
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 6.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_pubsub_subscription.dead_letter_subscription](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
+| [google_pubsub_subscription.subscription](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
+| [google_pubsub_topic.dead_letter_subscription_topic](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_labels"></a> [labels](#input\_labels) | A set of key/value label pairs to assign to this Topic. | `map(string)` | n/a | yes |
+| <a name="input_max_delivery_attempts"></a> [max\_delivery\_attempts](#input\_max\_delivery\_attempts) | The maximum number of delivery attempts for any message. The value must be between 5 and 100. | `number` | `5` | no |
+| <a name="input_message_retention_duration"></a> [message\_retention\_duration](#input\_message\_retention\_duration) | Indicates the minimum duration to retain a message after it is published to the topic. If this field is set, messages published to the topic in the last messageRetentionDuration are always available to subscribers. For instance, it allows any attached subscription to seek to a timestamp that is up to messageRetentionDuration in the past. If this field is not set, message retention is controlled by settings on individual subscriptions. | `string` | `null` | no |
+| <a name="input_subscription_name"></a> [subscription\_name](#input\_subscription\_name) | The name of the subscription. | `string` | n/a | yes |
+| <a name="input_topic_id"></a> [topic\_id](#input\_topic\_id) | A reference to a Topic resource, of the form projects/{project}/topics/{{name}} (as in the id property of a google\_pubsub\_topic), or just a topic name if the topic is in the same project as the subscription. | `string` | n/a | yes |
+| <a name="input_topic_name"></a> [topic\_name](#input\_topic\_name) | The name of the topic. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_subscription_id"></a> [subscription\_id](#output\_subscription\_id) | n/a |
+| <a name="output_subscription_name"></a> [subscription\_name](#output\_subscription\_name) | n/a |

--- a/variables.tf
+++ b/variables.tf
@@ -15,7 +15,7 @@ variable "max_delivery_attempts" {
 }
 
 variable "message_retention_duration" {
-  default     = null
+  default     = "2678400s"
   description = "Indicates the minimum duration to retain a message after it is published to the topic. If this field is set, messages published to the topic in the last messageRetentionDuration are always available to subscribers. For instance, it allows any attached subscription to seek to a timestamp that is up to messageRetentionDuration in the past. If this field is not set, message retention is controlled by settings on individual subscriptions."
   type        = string
 


### PR DESCRIPTION
* Updates the documentation.
* Fixes a small issue with the validation on the `message_retention_duration` variable by setting it to the max allowed instaed of `null`.
* Tests the release workflow to make sure it correctly pushes this to `1.0.0`.
