### PR TITLE
Add IAM Bindings and Update Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,46 +4,70 @@ This module create a Google PubSub Subscription as as well as a Topic/Subscripti
 
 We found that in order to follow the documentation for the provider, we were constantly having to create a ton of resources which increased the potential for mistakes. This module helps make sure it's more streamlined in our environment. 
 
-# Terraform-Docs
+## Usage
 
-## Requirements
+### Basic Configuration:
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.0 |
+```hcl
+module "ddm-pubsub-subscription" {
+  source  = "deseretdigital/ddm-pubsub-subscription/google"
+  version = "1.0.0"
+  
+  # Required
+  pubsub_service_account = {GKE_PUBSUB_SA_EMAIL}
+  subscription_name      = {YOUR_SUBSCRIPTION_NAME}
+  topic_id               = {PARENT_TOPIC_ID}
+  topic_name             = {PARENT_TOPIC_NAME}
 
-## Providers
+  # Optional
+  labels = {
+    env    = "prod"
+    region = {REGION}
+    # etc...
+  }
 
-| Name | Version |
-|------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 6.0 |
+  max_delivery_attempts      = {DEFAULT_100}
+  message_retention_duration = {DEFAULT_2678400s}
+}
+```
 
-## Modules
+This module creates a Google PubSub Subscription, a Google PubSub Topic for the dead letter messages, and a Google PubSub Subscription for the dead letters. It also applies the correct IAM bindings for the dead letter topic and subscription. 
 
-No modules.
+#### Example Usage
 
-## Resources
+```hcl
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}
 
-| Name | Type |
-|------|------|
-| [google_pubsub_subscription.dead_letter_subscription](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
-| [google_pubsub_subscription.subscription](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
-| [google_pubsub_topic.dead_letter_subscription_topic](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
+provider "google" {
+  # Configuration options
+}
 
-## Inputs
+resource "google_pubsub_topic" "example" {
+  name = "Example_TopicName"
+}
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_labels"></a> [labels](#input\_labels) | A set of key/value label pairs to assign to this Topic. | `map(string)` | n/a | yes |
-| <a name="input_max_delivery_attempts"></a> [max\_delivery\_attempts](#input\_max\_delivery\_attempts) | The maximum number of delivery attempts for any message. The value must be between 5 and 100. | `number` | `5` | no |
-| <a name="input_message_retention_duration"></a> [message\_retention\_duration](#input\_message\_retention\_duration) | Indicates the minimum duration to retain a message after it is published to the topic. If this field is set, messages published to the topic in the last messageRetentionDuration are always available to subscribers. For instance, it allows any attached subscription to seek to a timestamp that is up to messageRetentionDuration in the past. If this field is not set, message retention is controlled by settings on individual subscriptions. | `string` | `null` | no |
-| <a name="input_subscription_name"></a> [subscription\_name](#input\_subscription\_name) | The name of the subscription. | `string` | n/a | yes |
-| <a name="input_topic_id"></a> [topic\_id](#input\_topic\_id) | A reference to a Topic resource, of the form projects/{project}/topics/{{name}} (as in the id property of a google\_pubsub\_topic), or just a topic name if the topic is in the same project as the subscription. | `string` | n/a | yes |
-| <a name="input_topic_name"></a> [topic\_name](#input\_topic\_name) | The name of the topic. | `string` | n/a | yes |
+module "pubsub_subscription_module" {
+  source                 = "deseretdigital/ddm-pubsub-subscription/google"
+  version                = "~> 1.0.0"
+  pubsub_service_account = "service-{NUMBERS}@gcp-sa-pubsub.iam.gserviceaccount.com
+  subscription_name      = "Example_SubscriptionName"
+  topic_name             = google_pubsub_topic.example.name
+  topic_id               = google_pubsub_topic.example.id
+  
+  labels = {
+    date   = "2024-10-08"
+    region = "us-west3"
+    env    = "prod"
+  }
 
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| <a name="output_subscription_id"></a> [subscription\_id](#output\_subscription\_id) | n/a |
-| <a name="output_subscription_name"></a> [subscription\_name](#output\_subscription\_name) | n/a |
+  max_delivery_attempts      = 10
+  message_retention_duration = "84000s"
+}
+```

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ resource "google_pubsub_topic" "example" {
 module "pubsub_subscription_module" {
   source                 = "deseretdigital/ddm-pubsub-subscription/google"
   version                = "~> 1.0.0"
-  pubsub_service_account = "service-{NUMBERS}@gcp-sa-pubsub.iam.gserviceaccount.com
+  pubsub_service_account = "service-{NUMBERS}@gcp-sa-pubsub.iam.gserviceaccount.com"
   subscription_name      = "Example_SubscriptionName"
   topic_name             = google_pubsub_topic.example.name
   topic_id               = google_pubsub_topic.example.id

--- a/resources.tf
+++ b/resources.tf
@@ -13,6 +13,22 @@ resource "google_pubsub_topic" "dead_letter_subscription_topic" {
   labels = var.labels
 }
 
+resource "google_pubsub_topic_iam_binding" "assign_pubsub_publisher" {
+  topic = google_pubsub_topic.dead_letter_subscription_topic.id
+  role  = "roles/pubsub.publisher"
+  members = [
+    "serviceAccount:${var.pubsub_service_account}",
+  ]
+}
+
+resource "google_pubsub_topic_iam_binding" "assign_pubsub_subscriber" {
+  topic = google_pubsub_topic.dead_letter_subscription_topic.id
+  role  = "roles/pubsub.subscriber"
+  members = [
+    "serviceAccount:${var.pubsub_service_account}",
+  ]
+}
+
 resource "google_pubsub_subscription" "dead_letter_subscription" {
   name  = "${var.subscription_name}_DeadLetter"
   topic = google_pubsub_topic.dead_letter_subscription_topic.id

--- a/terraform-docs.md
+++ b/terraform-docs.md
@@ -1,0 +1,46 @@
+# Terraform-Docs
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 6.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_pubsub_subscription.dead_letter_subscription](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
+| [google_pubsub_subscription.subscription](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
+| [google_pubsub_topic.dead_letter_subscription_topic](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
+| [google_pubsub_topic_iam_binding.assign_pubsub_publisher](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic_iam_binding) | resource |
+| [google_pubsub_topic_iam_binding.assign_pubsub_subscriber](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic_iam_binding) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_labels"></a> [labels](#input\_labels) | A set of key/value label pairs to assign to this Topic. | `map(string)` | n/a | yes |
+| <a name="input_max_delivery_attempts"></a> [max\_delivery\_attempts](#input\_max\_delivery\_attempts) | The maximum number of delivery attempts for any message. The value must be between 5 and 100. | `number` | `100` | no |
+| <a name="input_message_retention_duration"></a> [message\_retention\_duration](#input\_message\_retention\_duration) | Indicates the minimum duration to retain a message after it is published to the topic. If this field is set, messages published to the topic in the last messageRetentionDuration are always available to subscribers. For instance, it allows any attached subscription to seek to a timestamp that is up to messageRetentionDuration in the past. If this field is not set, message retention is controlled by settings on individual subscriptions. | `string` | `"2678400s"` | no |
+| <a name="input_pubsub_service_account"></a> [pubsub\_service\_account](#input\_pubsub\_service\_account) | The service account to be used by the Pub/Sub system. Looks like 'service-<project-number>@gcp-sa-pubsub.iam.gserviceaccount.com'. | `string` | n/a | yes |
+| <a name="input_subscription_name"></a> [subscription\_name](#input\_subscription\_name) | The name of the subscription. | `string` | n/a | yes |
+| <a name="input_topic_id"></a> [topic\_id](#input\_topic\_id) | A reference to a Topic resource, of the form projects/{project}/topics/{{name}} (as in the id property of a google\_pubsub\_topic), or just a topic name if the topic is in the same project as the subscription. | `string` | n/a | yes |
+| <a name="input_topic_name"></a> [topic\_name](#input\_topic\_name) | The name of the topic. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_subscription_id"></a> [subscription\_id](#output\_subscription\_id) | n/a |
+| <a name="output_subscription_name"></a> [subscription\_name](#output\_subscription\_name) | n/a |

--- a/terraform-docs.md
+++ b/terraform-docs.md
@@ -30,7 +30,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_labels"></a> [labels](#input\_labels) | A set of key/value label pairs to assign to this Topic. | `map(string)` | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | A set of key/value label pairs to assign to this Topic. | `map(string)` | `{}` | no |
 | <a name="input_max_delivery_attempts"></a> [max\_delivery\_attempts](#input\_max\_delivery\_attempts) | The maximum number of delivery attempts for any message. The value must be between 5 and 100. | `number` | `100` | no |
 | <a name="input_message_retention_duration"></a> [message\_retention\_duration](#input\_message\_retention\_duration) | Indicates the minimum duration to retain a message after it is published to the topic. If this field is set, messages published to the topic in the last messageRetentionDuration are always available to subscribers. For instance, it allows any attached subscription to seek to a timestamp that is up to messageRetentionDuration in the past. If this field is not set, message retention is controlled by settings on individual subscriptions. | `string` | `"2678400s"` | no |
 | <a name="input_pubsub_service_account"></a> [pubsub\_service\_account](#input\_pubsub\_service\_account) | The service account to be used by the Pub/Sub system. Looks like 'service-<project-number>@gcp-sa-pubsub.iam.gserviceaccount.com'. | `string` | n/a | yes |

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,11 @@
 variable "labels" {
   description = "A set of key/value label pairs to assign to this Topic."
   type        = map(string)
+  default     = {}
 }
 
 variable "max_delivery_attempts" {
-  default     = 5
+  default     = 100
   description = "The maximum number of delivery attempts for any message. The value must be between 5 and 100."
   type        = number
 
@@ -22,6 +23,15 @@ variable "message_retention_duration" {
   validation {
     condition     = can(regex("^\\d+s$", var.message_retention_duration))
     error_message = "Value must be a duration represented in seconds. Example: 86400s"
+  }
+}
+
+variable "pubsub_service_account" {
+  description = "The service account to be used by the Pub/Sub system. Looks like 'service-<project-number>@gcp-sa-pubsub.iam.gserviceaccount.com'."
+  type        = string
+  validation {
+    condition     = can(regex("^service-\\d+@gcp-sa-pubsub\\.iam\\.gserviceaccount\\.com$", var.pubsub_service_account))
+    error_message = "value must be a valid service account email address."
   }
 }
 


### PR DESCRIPTION
- **feat: add service account and refactor documentation**
- **chore: fix quotations**

**BREAKING CHANGE**

In this update, I added the IAM bindings and supporting variables in order to assign `roles/pubsub.publisher` and `roles/pubsub.publisher` to the subscription. This should resolve a warning after creation in the console that the subscription does not have the correct permissions to use the dead letter topic/subscription.

I also:
* Split off the `terraform-docs` output into it's own `.md` file to make the view on the registry more usable. 
* Added a default to the `labels` variable so it is no longer required. We use it, but that doesn't mean it is required should someone else stumble across it. 
* Drastically updated the documentation to have basic configuration and an example implementation. 
