### PR TITLE
Adds Release Notifier

### DIFF
--- a/.github/workflows/release-tagging.yml
+++ b/.github/workflows/release-tagging.yml
@@ -35,3 +35,53 @@ jobs:
                 tag: ${{ needs.release-tag.outputs.RELEASE_TAG }}
                 name: Release ${{ needs.release-tag.outputs.RELEASE_TAG }}
                 body: ${{ needs.release-tag.outputs.RELEASE_TAG }}
+
+    release-notifier:
+      runs-on: ubuntu-latest
+      needs: ['release-tag', 'create-release']
+      name: 'Release Notifier'
+      steps:
+        - name: Send Notification
+          uses: slackapi/slack-github-action@v1.27.0
+          env:
+            SLACK_BOT_TOKEN: ${{ secrets.RELEASE_SLACKBOT_TOKEN }}
+          with:
+            channel-id: release
+            payload: |
+              {
+                  "blocks": [
+                      {
+                          "type": "header",
+                          "text": {
+                              "type": "plain_text",
+                              "text": ":terraform: ${{github.event.repository.name}} release",
+                              "emoji": true
+                          }
+                      },
+                      {
+                          "type": "section",
+                          "text": {
+                              "type": "mrkdwn",
+                              "text": "*${{github.event.repository.name}}* release."
+                          },
+                          "accessory": {
+                              "type": "button",
+                              "text": {
+                                  "type": "plain_text",
+                                  "text": "${{needs.release-tag.outputs.RELEASE_TAG}}",
+                                  "emoji": true
+                              },
+                              "url": "https://github.com/deseretdigital/${{github.event.repository.name}}/releases/tag/${{needs.release-tag.outputs.RELEASE_TAG}}"
+                          }
+                      },
+                      {
+                          "type": "context",
+                          "elements": [
+                              {
+                                  "type": "mrkdwn",
+                                  "text": "_This is an automated message. It does not indicate the deploy was successful, and it will not post here if it has failed. Please check the action run for more details._"
+                              }
+                          ]
+                      }
+                  ]
+              }

--- a/output.tf
+++ b/output.tf
@@ -1,7 +1,9 @@
 output "subscription_id" {
-  value = google_pubsub_subscription.subscription.id
+  value       = google_pubsub_subscription.subscription.id
+  description = "The ID of the created subscription."
 }
 
 output "subscription_name" {
-  value = google_pubsub_subscription.subscription.name
+  value       = google_pubsub_subscription.subscription.name
+  description = "The name of the created subscription."
 }


### PR DESCRIPTION
Adds the `release-notifier` logic to post to the internal slack when a new release is created.

Also adds descriptions to the outputs.
