### PR TITLE
Updated Release Notes Action

### DIFF
--- a/.github/workflows/release-tagging.yml
+++ b/.github/workflows/release-tagging.yml
@@ -34,7 +34,7 @@ jobs:
               with:
                 tag: ${{ needs.release-tag.outputs.RELEASE_TAG }}
                 name: Release ${{ needs.release-tag.outputs.RELEASE_TAG }}
-                body: ${{ needs.release-tag.outputs.RELEASE_TAG }}
+                generateReleaseNotes: true
 
     release-notifier:
       runs-on: ubuntu-latest


### PR DESCRIPTION
Updated the `release-notifier` job to generate release notes instead of just putting the version number in the body. I haven't used this anywhere else, but I wanted to see how it came out. 
