### PR TITLE
fix(pubsub): add explicit dependency for dead letter topic IAM permission

### DIFF
--- a/resources.tf
+++ b/resources.tf
@@ -7,6 +7,10 @@ resource "google_pubsub_subscription" "subscription" {
     dead_letter_topic     = google_pubsub_topic.dead_letter_subscription_topic.id
     max_delivery_attempts = var.max_delivery_attempts
   }
+
+  depends_on = [
+    google_pubsub_topic_iam_member.assign_pubsub_publisher
+  ]
 }
 
 resource "google_pubsub_topic" "dead_letter_subscription_topic" {


### PR DESCRIPTION
The Pub/Sub subscription with a dead letter policy could be created before
the Pub/Sub service account was granted publish permission on the dead letter
topic. Terraform was creating the subscription and IAM binding in parallel,
which caused a race condition.

Add an explicit depends_on from the subscription to the
google_pubsub_topic_iam_member resource to ensure the publisher permission
is granted before the subscription is created.

This prevents failed messages from being dropped due to missing permissions
on the dead letter topic.
